### PR TITLE
Use identifiers in edges instead of objects

### DIFF
--- a/bw_interface_schemas/__init__.py
+++ b/bw_interface_schemas/__init__.py
@@ -7,9 +7,11 @@ __all__ = (
     "DataSource",
     "Edge",
     "ElementaryFlow",
+    "Graph",
     "ImpactAssessmentMethod",
     "ImpactCategory",
     "InventoryNode",
+    "load_graph",
     "Node",
     "NodeTypes",
     "Normalization",
@@ -24,14 +26,12 @@ __all__ = (
     "TechnosphereQuantitativeEdge",
     "Weighting",
     "WeightingQuantitativeEdge",
-    "Graph",
-    "GraphLoader",
 )
 
 __version__ = "0.2"
 
 
-from bw_interface_schemas.graph import Graph, GraphLoader
+from bw_interface_schemas.graph import Graph, load_graph
 from bw_interface_schemas.models import (
     BiosphereQuantitativeEdge,
     CharacterizationQuantitativeEdge,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,70 +6,70 @@ import bw_interface_schemas as schema
 @pytest.fixture
 def bike_as_dict() -> dict:
     return {
-        "nodes": [
-            {
+        "nodes": {
+            "bike_db": {
                 "node_type": "database",
                 "name": "bike_db",
                 "license": "CC-BY",
             },
-            {
+            "natural gas extraction": {
                 "node_type": "process",
                 "name": "natural gas extraction",
                 "location": "NO",
             },
-            {
+            "natural gas": {
                 "node_type": "product",
                 "name": "natural gas",
                 "unit": "MJ",
             },
-            {
+            "carbon fibre production": {
                 "node_type": "process",
                 "name": "carbon fibre production",
                 "location": "DE",
             },
-            {
+            "carbon fibre": {
                 "node_type": "product",
                 "name": "carbon fibre",
                 "unit": "kg",
             },
-            {
+            "bike manufacturing": {
                 "node_type": "process",
                 "name": "bike manufacturing",
                 "location": "DK",
             },
-            {
+            "bicycle": {
                 "node_type": "product",
                 "name": "bicycle",
                 "unit": "number",
             },
-            {
+            "CO2": {
                 "node_type": "elementary_flow",
                 "name": "CO2",
                 "context": ["air"],
                 "unit": "kg",
             },
-            {
+            "IPCC": {
                 "node_type": "impact_assessment_method",
                 "name": "IPCC",
                 "license": "CC-BY",
             },
-            {
+            "IPCC - 100 years": {
                 "node_type": "impact_category",
                 "name": ["IPCC", "100 years"],
                 "unit": "kg CO2-eq.",
             },
-        ],
+        },
         "edges": [
             {
                 "edge_type": "belongs_to",
-                "source": ["IPCC", "100 years"],
+                "source": "IPCC - 100 years",
                 "target": "IPCC",
             },
             {
                 "edge_type": "characterization",
                 "amount": 1.0,
                 "source": "CO2",
-                "target": ["IPCC", "100 years"],
+                "target": "IPCC - 100 years",
             },
             {
                 "edge_type": "biosphere",
@@ -131,82 +131,5 @@ def bike_as_dict() -> dict:
 
 
 @pytest.fixture
-def bike_as_graph() -> schema.Graph:
-    db = schema.Database(name="bike", license="CC-BY")
-    ng_extraction = schema.Process(name="natural gas extraction", location="NO")
-    ng = schema.Product(name="natural gas", unit="MJ")
-    cf_production = schema.Process(name="carbon fibre production", location="DE")
-    cf = schema.Product(name="carbon fibre", unit="kg")
-    bike_manufacture = schema.Process(name="bike manufacturing", location="DK")
-    bike = schema.Product(name="bike", unit="bicycle")
-    co2 = schema.ElementaryFlow(name="CO2", unit="kg", context=["air"])
-    ipcc = schema.ImpactAssessmentMethod(name="IPCC", license="CC-BY")
-    gwp = schema.ImpactCategory(name=["IPCC", "100 years"], unit="CO2-eq.")
-
-    return schema.Graph(
-        nodes=[
-            db,
-            ipcc,
-            gwp,
-            ng_extraction,
-            ng,
-            cf_production,
-            cf,
-            bike_manufacture,
-            bike,
-            co2,
-        ],
-        edges=[
-            schema.QualitativeEdge(
-                source=gwp,
-                target=ipcc,
-                edge_type=schema.QualitativeEdgeTypes.belongs_to,
-            ),
-            schema.CharacterizationQuantitativeEdge(source=co2, target=gwp, amount=1),
-            schema.TechnosphereQuantitativeEdge(
-                source=ng,
-                target=cf_production,
-                amount=237,
-            ),
-            schema.TechnosphereQuantitativeEdge(
-                source=cf,
-                target=bike_manufacture,
-                amount=2.5,
-            ),
-            schema.BiosphereQuantitativeEdge(
-                source=cf_production, target=co2, amount=26.6
-            ),
-            schema.TechnosphereQuantitativeEdge(
-                source=ng_extraction,
-                target=ng,
-                amount=1,
-                functional=True,
-            ),
-            schema.TechnosphereQuantitativeEdge(
-                source=cf_production,
-                target=cf,
-                amount=1,
-                functional=True,
-            ),
-            schema.TechnosphereQuantitativeEdge(
-                source=bike_manufacture,
-                target=bike,
-                amount=1,
-                functional=True,
-            ),
-        ]
-        + [
-            schema.QualitativeEdge(
-                source=node, target=db, edge_type=schema.QualitativeEdgeTypes.belongs_to
-            )
-            for node in (
-                ng_extraction,
-                ng,
-                cf_production,
-                cf,
-                bike_manufacture,
-                bike,
-                co2,
-            )
-        ],
-    )
+def bike_as_graph(bike_as_dict) -> schema.Graph:
+    return schema.load_graph(bike_as_dict)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1,4 +1,4 @@
-from bw_interface_schemas import GraphLoader
+from bw_interface_schemas import load_graph
 
 
 def test_dump_graph(bike_as_graph):
@@ -6,4 +6,4 @@ def test_dump_graph(bike_as_graph):
 
 
 def test_construct_graph(bike_as_dict):
-    assert GraphLoader(identifier_field="name").load(bike_as_dict, use_identifiers=True)
+    assert load_graph(bike_as_dict)


### PR DESCRIPTION
Currently the `Edge` schemas assume that `source` and `target` are objects which have properties we can valdiate. This PR changes the `Edge` schema to use `Identifier` instead (either a `str` or an `int`), and changes the `Graph` "nodes" schema to be a list of `{Identifier: Node}` instead of a list of `Node` objects.

The original design was responding to both SimaPro CSV and ecospold2, which both don't have unique identifiers for processes and products. This is an unfortunate reality of current data formats but we don't have to drop down to their level.

The PR has the following effects:
- We are explicit about the need for an identifier for nodes, allowing for nodes with identical or similar attributes to be resolved unambiguously. However, we don't proscribe how the identifier is labelled or associated with the node.
- `Graph.nodes` being a dictionary with keys as identifiers means lookup is fast and we don't need to test for object equality (i.e. no more `[node for node in graph.nodes if node == other]`).
- No nested pydantic classes (i.e. `Edge.source` is a `Node`), so we can much more easily validate directly against basic python types.
- Some validation code moves from `Edge` to `Graph` as it now needs the full graph context to check for edge reference attributes.
- `GraphLoader` complexity is dramatically reduced, its now a simple function.
- Graph validation is easier as we don't need to "re-hydrate" graphs that were made using references and build on `GraphLoader` code which would re-insert the referenced objects.